### PR TITLE
Correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Simple web server library
 paragraph=The library supports HTTP GET and POST requests, provides argument parsing, handles one client at a time.
 category=Communication
 url=
-architectures=ESP32
+architectures=esp32


### PR DESCRIPTION
The previous `architectures` value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library ESP32WebServer claims to run on (ESP32) architecture(s) and may be incompatible with your current board which runs on (esp32) architecture(s).
```
The architectures values are case sensitive and the correct architecture is `esp32`, not `ESP32`.

The previous `architectures` value caused the library's examples to be placed under the **File > Examples > INCOMPATIBLE > ESP32WebServer** menu.